### PR TITLE
Set clock speed to 804MHz + L2 on NEW3DS

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -15,6 +15,7 @@ static const size_t SOC_SHAREDMEM_SIZE = 0x200000;
 static u32 *soc_sharedmem_ptr = NULL;
 
 int main(int argc, char **argv) {
+  osSetSpeedupEnable(true);
   gfxInitDefault();
 
   soc_sharedmem_ptr = (u32 *)memalign(0x1000, SOC_SHAREDMEM_SIZE);


### PR DESCRIPTION
This will speed up everything on NEW3DS including RSA key generation and rendering where there are a lot of text to draw.
It is safe to call `osSetSpeedupEnable(true)` on OLD3DS, it just do nothing.
